### PR TITLE
Hover text description of GCodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/client/extension.js
+++ b/client/extension.js
@@ -1,19 +1,21 @@
 const vscode = require('vscode');
 var fetch = require("node-fetch");
 
-let urlLookup = new Object();
+var urlLookup;
 
 function activate(context) {
 
-    console.log('Congratulations, your extension "star-rod" is now active!');
-    // https://www.chrishasz.com/blog/2020/07/28/vscode-how-to-use-local-storage-api/#:~:text=the%20Memento%20class%20in%20the,tune%20how%20you%20store%20data.
-    //const storage = context.globalState
+    console.log('GCode hover text is active');
 
-
-    fetch(`https://api.github.com/repos/MarlinFirmware/MarlinDocumentation/contents/_gcode`)
+    if (urlLookup == null)
+    {
+        console.debug('Fetching cache of documentation');
+        urlLookup = new Object();
+        fetch(`https://api.github.com/repos/MarlinFirmware/MarlinDocumentation/contents/_gcode`)
         .then(res => res.json())
         .then(body => parseRepoContents(body))
         .catch((error) => console.log(error));
+    }
 
     disposable = vscode.languages.registerHoverProvider('gcode', {
         async provideHover(document, position, token) {

--- a/client/extension.js
+++ b/client/extension.js
@@ -1,0 +1,92 @@
+const vscode = require('vscode');
+var fetch = require("node-fetch");
+
+let urlLookup = new Object();
+
+function activate(context) {
+
+    console.log('Congratulations, your extension "star-rod" is now active!');
+    // https://www.chrishasz.com/blog/2020/07/28/vscode-how-to-use-local-storage-api/#:~:text=the%20Memento%20class%20in%20the,tune%20how%20you%20store%20data.
+    //const storage = context.globalState
+
+
+    fetch(`https://api.github.com/repos/MarlinFirmware/MarlinDocumentation/contents/_gcode`)
+        .then(res => res.json())
+        .then(body => parseRepoContents(body))
+        .catch((error) => console.log(error));
+
+    disposable = vscode.languages.registerHoverProvider('gcode', {
+        async provideHover(document, position, token) {
+            const range = document.getWordRangeAtPosition(position);
+            const word = document.getText(range);
+
+            // format the word correctly
+            const regex = /\s*([A-Za-z])(\d+)\s*/
+            const matches = word.match(regex);
+            if(!isNaN(matches[2]))
+            {
+                const lookup = matches[1] + matches[2].padStart(3,"0");
+                if (urlLookup[lookup] != null)
+                {
+                    // Can get the contents of the repo here. Need to parse out the hypenated entries (like G000-G001) to make a lookup
+                    //https://api.github.com/repos/MarlinFirmware/MarlinDocumentation/contents/_gcode
+                    const url = urlLookup[lookup];
+                    /*
+                    const prommise = fetch(url)
+                        .then(res => res.text())
+                        .then(body => {
+                            const hoverText = parseDocs(body)
+                            return new vscode.Hover({value: "hoverText"});
+                        })
+                        .catch((error) => console.log(error));
+    
+                    await promise;
+                    */
+
+                    try {
+                        const response = await fetch(url);
+                        const json = await response.text();
+                        const hoverText = parseDocs(json);
+                        return new vscode.Hover(hoverText);
+                    } catch (error) {
+                        console.log(error);
+                    }
+
+               await promise;
+
+                    return promise;
+                }
+            }
+
+            return;
+        }
+    });    
+
+    context.subscriptions.push(disposable);
+}
+
+function deactivate() { }
+
+function parseRepoContents(json)
+{
+    json.forEach(element => {
+        const filename = element.name.split(".")[0];
+        const numberParts = filename.split("-");
+        numberParts.forEach(numberPart => {
+            urlLookup[numberPart] = element.download_url;
+        });
+    });
+}
+
+function parseDocs(text) 
+{
+    const title = text.match(/title: ([^\n]*)/)[1];
+    const brief = text.match(/brief: ([^\n]*)/)[1];
+    return new vscode.MarkdownString(`**${title}** \n\n ${brief}`);
+
+}
+
+module.exports = {
+    activate,
+    deactivate
+}

--- a/client/extension.js
+++ b/client/extension.js
@@ -29,20 +29,8 @@ function activate(context) {
             if(!isNaN(matches[2]))
             {
                 // Format the string correctly (i.e. with leading zeros)
-                const lookup = matches[1] + matches[2].padStart(3,"0");
-                const rawInfoUrl = urlLookup[lookup].download_url;
-                if (rawInfoUrl != null)
-                {
-                    try {
-                        const response = await fetch(rawInfoUrl);
-                        const json = await response.text();
-                        const docs = parseDocs(json);
-                        const hoverText = `**${docs.title}** \n\n ${docs.brief} \n\n <${urlLookup[lookup].docs_url}>`
-                        return new vscode.Hover(hoverText);
-                    } catch (error) {
-                        console.log(error);
-                    }
-                }
+                const gcode = matches[1] + matches[2].padStart(3,"0");
+                return new vscode.Hover(await getHoverText(gcode));
             }
         }
     });    
@@ -51,6 +39,31 @@ function activate(context) {
 }
 
 function deactivate() { }
+
+async function getHoverText(gcode)
+{
+    if (urlLookup[gcode].hoverText == null)
+    {
+        // Can we generate the info?
+        if (urlLookup[gcode].download_url != null)
+        {
+            const rawInfoUrl = urlLookup[gcode].download_url;
+            if (rawInfoUrl != null)
+            {
+                try {
+                    const response = await fetch(rawInfoUrl);
+                    const json = await response.text();
+                    const docs = parseDocs(json);
+                    urlLookup[gcode].hoverText = `**${docs.title}** \n\n ${docs.brief} \n\n <${urlLookup[gcode].docs_url}>`
+                } catch (error) {
+                    console.log(error);
+                }
+            }
+        }
+    
+    }
+    return urlLookup[gcode].hoverText;
+}
 
 function parseRepoContents(json)
 {

--- a/client/extension.js
+++ b/client/extension.js
@@ -25,8 +25,10 @@ function activate(context) {
             // format the word correctly
             const regex = /\s*([A-Za-z])(\d+)\s*/
             const matches = word.match(regex);
+            // If the second part is a number then search the lookup for the documentation
             if(!isNaN(matches[2]))
             {
+                // Format the string correctly (i.e. with leading zeros)
                 const lookup = matches[1] + matches[2].padStart(3,"0");
                 if (urlLookup[lookup] != null)
                 {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nc-gcode",
     "displayName": "nc-gcode",
     "description": "G-code syntax highlighter",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "publisher": "ML2",
     "author": {
         "name": "Milys",
@@ -11,11 +11,18 @@
     "maintainers": [{
         "name": "scottmwyant",
         "url": "https://github.com/scottmwyant"
+    },
+    {
+        "name": "Stevil Knevil",
+        "url": "https://github.com/StevilKnevil"
     }],
     "scripts": {
         "pack": "vsce package"
     },
     "preview": true,
+    "activationEvents": [
+        "onLanguage:gcode"
+     ],    
     "engines": {
         "vscode": "^1.19.0"
     },
@@ -32,7 +39,11 @@
         "color": "#E4F2FF",
         "theme": "light"
     },
+    "main": "./client/extension.js",
     "contributes": {
+        "capabilities": {
+            "hoverProvider": "true"
+        },
         "languages": [{
             "id": "gcode",
             "aliases": [
@@ -88,5 +99,7 @@
             "scopeName": "source.gcode",
             "path": "./gcode.tmLanguage.json"
         }]
-    }
+    },
+    "dependencies" :
+        { "node-fetch" : ">2.6.0" }
 }


### PR DESCRIPTION
This adds functionality so that when you hover over a gcode it displays information pulled directly from the Marlin firmware documentation (https://marlinfw.org/docs/gcode/G000-G001.html). It also provides a link to the source documentation for more detail.