### PR TITLE
Changed how block & line comments work.

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": ";",
+        "lineComment?": "/",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        // "blockComment": [ "/*", "*/" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Modified how (Ctrl, ⌘) + / commenting works.

G-Code doesn't support block comments; this behavior was switched to make the selected line(s) optional.

Putting a "/" at the start of a line lets the machine control know that line should be skipped if the "Block Delete" option is on.